### PR TITLE
Fix theme.ts > properly line-breaks between the colorblocks

### DIFF
--- a/packages/nuxt-ui-layer/plugins/theme.ts
+++ b/packages/nuxt-ui-layer/plugins/theme.ts
@@ -14,7 +14,7 @@ const individualPalette = (themePalette: ThemePalette) => {
     if (themePalette) {
         return Object.entries(themePalette).map(([key, value]) => {
             return paletteToStyle(key as Level, value)
-        })
+        }).join(`;\r\n`)
     }
 }
 


### PR DESCRIPTION
.join(`;\r\n`) fixes an err with the linebreaks between colorblocks. Otherwise they are malformed and produce this kind of vars in the browser: --primary-700: 1 137 55;
--primary-800: 22 101 52;
--primary-900: 20 83 45,--secondary-50: 245 243 255;

the err is visible in your video as well ;)